### PR TITLE
Added CentOS 7 support. Added optional ipset and gd support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,16 @@ language: python
 python: '2.7'
 
 env:
-  matrix:
+  global:
     - SITE=local_host.yml
+  matrix:
+    - VARS=""
+    - VARS='ipset=true statistical_graphs=false'
+    - VARS='ipset=false statistical_graphs=true'
+    - VARS='ipset=true statistical_graphs=true'
 
 before_install:
-  - sudo apt-get update -qq
+  - sudo apt-get update
 
 install:
   - pip install ansible
@@ -16,7 +21,7 @@ install:
 
 script:
   - ansible-playbook -i meta/tests/inventory meta/tests/$SITE --syntax-check
-  - ansible-playbook -i meta/tests/inventory meta/tests/$SITE --connection=local --sudo
+  - ansible-playbook -i meta/tests/inventory meta/tests/$SITE --connection=local --sudo --extra-vars="$VARS"
 
 notifications:
   email:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,2 @@
+ipset: false
+statistical_graphs: false

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,8 +1,10 @@
 ---
 # Restart CSF
 - name: restart csf
+  sudo: true
   command: csf -r
 
 # Restart LFD
 - name: restart lfd
+  sudo: true
   service: name=lfd state=restarted

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,6 +11,9 @@ galaxy_info:
   - name: Debian
     versions:
     - all
+  - name: RedHat
+    versions:
+      - 7
   categories:
   - packaging
   - system

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -30,15 +30,48 @@
   when: result|failed
 
 # Install lib-perl which is sometimes required for retrieving HTTPS URL's
-- name: install packages [Debian]
+- name: install package libwww-perl [Debian]
   sudo: true
   apt: name=libwww-perl state=present
   when: "ansible_os_family == 'Debian'"
 
-- name: install packages [RedHat]
+- name: install package perl-libwww-perl [RedHat]
   sudo: true
   yum: name=perl-libwww-perl state=present
   when: "ansible_os_family == 'RedHat'"
+
+# Install ipset if desired
+- name: install package ipset [Debian]
+  sudo: true
+  apt: name=ipset state=present
+  when: "ipset and ansible_os_family == 'Debian'"
+
+- name: install package ipset [RedHat]
+  sudo: true
+  yum: name=ipset state=present
+  when: "ipset and ansible_os_family == 'RedHat'"
+
+# Install perl GD Graph if desired
+- name: install package libgd-graph-perl [Debian]
+  sudo: true
+  apt: name=libgd-graph-perl state=present
+  when: "statistical_graphs and ansible_os_family == 'Debian'"
+
+- name: install package perl-GDGraph [RedHat]
+  sudo: true
+  yum: name=perl-GDGraph state=present
+  when: "statistical_graphs and ansible_os_family == 'RedHat'"
+
+# Firewalld needs to be disabled to prevent bad stuff from happening with CSF in CentOS7
+- name: Disable firewalld on [RedHat] and [CentOS7]
+  service: name=firewalld state=stopped enabled=no
+  when: "ansible_os_family == 'RedHat' and ansible_distribution_major_version == '7'"
+
+# ifconfig (net-tools) needs to be installed for CSF to work properly in CentOS7
+- name: install package net-tools [RedHat]
+  sudo: true
+  yum: name=net-tools state=present
+  when: "ansible_os_family == 'RedHat' and ansible_distribution_major_version == '7'"
 
 # Install CSF
 - name: install csf


### PR DESCRIPTION
Hi James,

First of all, many thanks for creating this role. I had something local, but it was not as elegant as yours (I especially like how you handled the configuration for csf.conf!)

I saw you added initial support for RHEL / CentOS 7 and I hope you didn't mind me forking from your project and adding a few minor additions to make things work on CentOS 7.
Have a look at my pull request and if you need me to make any changes, please let me know.

I'm a bit new at this Github thing and I've tried to keep things in the same style as you had.
I also checked within Vagrant that the project still works with Ubuntu.

A short list:
- Remove firewalld on RHEL / CentOS 7. And install deps
- Allow install of ipset (default off)
- Allow install of libgd-perl for statistical screens (default off)
- Minor fix where the csf / lfd restart required sudo

Thanks again!

Regards,

Barry
