### PR TITLE
Only fail disable firewalld when it's actually installed.

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -7,23 +7,19 @@
   ignore_errors: true
   changed_when: false
 
-# Create a temp dir for our install
-- name: create temp dir
-  command: mkdir -p /tmp/csf
-  when: result|failed
-
 # Download the CSF file
 - name: download csf files
-  command: "wget https://download.configserver.com/csf.tgz"
-  args:
-    chdir: /tmp/csf
+  get_url:
+    dest: /usr/src/csf.tgz
+    url: https://download.configserver.com/csf.tgz
   when: result|failed
 
 # Extract tar.gz
 - name: extract csf files
-  command: tar -zxf csf.tgz
-  args:
-    chdir: /tmp/csf
+  unarchive:
+    src: /usr/src/csf.tgz
+    dest: /usr/src
+    copy: no
   when: result|failed
 
 # Install lib-perl which is sometimes required for retrieving HTTPS URL's
@@ -69,10 +65,12 @@
 - name: install csf
   command: sh install.sh
   args:
-    chdir: /tmp/csf/csf
+    chdir: /usr/src/csf
   when: result|failed
 
 # Cleanup TEMP dir we created
 - name: cleanup csf files
-  command: rm -rf /tmp/csf
-  when: result|failed
+  file: path={{ item }} state=absent
+  with_items:
+   - /usr/src/csf/
+   - /usr/src/csf.tgz

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -56,7 +56,9 @@
 # Firewalld needs to be disabled to prevent bad stuff from happening with CSF in CentOS7
 - name: Disable firewalld on [RedHat] and [CentOS7]
   service: name=firewalld state=stopped enabled=no
+  register: disable_firewalld
   when: "ansible_os_family == 'RedHat' and ansible_distribution_major_version == '7'"
+  failed_when: "disable_firewalld|failed and 'could not find' not in disable_firewalld.msg"
 
 # ifconfig (net-tools) needs to be installed for CSF to work properly in CentOS7
 - name: install package net-tools [RedHat]


### PR DESCRIPTION
Not all cloud providers install firewalld by default in their templates which breaks this role on those installations.
