### PR TITLE
Only fail disable firewalld when it's actually installed.

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -56,7 +56,9 @@
 # Firewalld needs to be disabled to prevent bad stuff from happening with CSF in CentOS7
 - name: Disable firewalld on [RedHat] and [CentOS7]
   service: name=firewalld state=stopped enabled=no
+  register: disable_firewalld
   when: "ansible_os_family == 'RedHat' and ansible_distribution_major_version == '7'"
+  failed_when: "disable_firewalld|failed and 'could not find' not in disable_firewalld.msg"
 
 # ifconfig (net-tools) needs to be installed for CSF to work properly in CentOS7
 - name: install package net-tools [RedHat]


### PR DESCRIPTION
Not all cloud providers install firewalld by default in their templates which breaks this role on those installations.
