### PR TITLE
Converted commands to Ansible modules and moved the temp directory.

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -72,5 +72,5 @@
 - name: cleanup csf files
   file: path={{ item }} state=absent
   with_items:
-   - /usr/src/csf/
+   - /usr/src/csf
    - /usr/src/csf.tgz

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -7,23 +7,19 @@
   ignore_errors: true
   changed_when: false
 
-# Create a temp dir for our install
-- name: create temp dir
-  command: mkdir -p /tmp/csf
-  when: result|failed
-
 # Download the CSF file
 - name: download csf files
-  command: "wget https://download.configserver.com/csf.tgz"
-  args:
-    chdir: /tmp/csf
+  get_url:
+    dest: /usr/src/csf.tgz
+    url: https://download.configserver.com/csf.tgz
   when: result|failed
 
 # Extract tar.gz
 - name: extract csf files
-  command: tar -zxf csf.tgz
-  args:
-    chdir: /tmp/csf
+  unarchive:
+    src: /usr/src/csf.tgz
+    dest: /usr/src
+    copy: no
   when: result|failed
 
 # Install lib-perl which is sometimes required for retrieving HTTPS URL's
@@ -69,10 +65,12 @@
 - name: install csf
   command: sh install.sh
   args:
-    chdir: /tmp/csf/csf
+    chdir: /usr/src/csf
   when: result|failed
 
 # Cleanup TEMP dir we created
 - name: cleanup csf files
-  command: rm -rf /tmp/csf
-  when: result|failed
+  file: path={{ item }} state=absent
+  with_items:
+   - /usr/src/csf/
+   - /usr/src/csf.tgz


### PR DESCRIPTION
The installer has been converted to use Ansible's modules instead of plain commands. The temp directory was moved at the same time to make sure we can install CSF on servers with noexec on /tmp.
