### PR TITLE
Fix playbook in Ansible 2.2

### DIFF
--- a/tasks/includes.yml
+++ b/tasks/includes.yml
@@ -13,7 +13,7 @@
     dest="/etc/csf/csf.allow"
     regexp="^Include /etc/csf/includes/{{ item.rule }}.allow$"
     line="Include /etc/csf/includes/{{ item.rule }}.allow"
-  with_items: csf_rules
+  with_items: "{{ csf_rules }}"
   when: "csf_rules is defined"
   notify: restart csf
 
@@ -23,6 +23,6 @@
     src="rules/common/{{ item.rule }}.allow"
     dest="/etc/csf/includes/{{ item.rule }}.allow"
     owner=root group=root mode=0600
-  with_items: csf_rules
+  with_items: "{{ csf_rules }}"
   when: "csf_rules is defined"
   notify: restart csf


### PR DESCRIPTION
There was an error prior to this change:

```
FAILED! => {"failed": true, "msg": "the field 'args' has an invalid value, which appears to include a variable that is undefined. The error was: 'ansible.vars.unsafe_proxy.AnsibleUnsafeText object' has no attribute 'rule'\n\nThe error appears to have been in '[...]/roles/mooash.csf-ansible-role/tasks/includes.yml': line 11, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n# Enable rules in csf.allow\n- name: enable common csf.allow rules\n  ^ here\n"}
```