### PR TITLE
Allow *.allow to be a template

### DIFF
--- a/tasks/includes.yml
+++ b/tasks/includes.yml
@@ -13,16 +13,16 @@
     dest="/etc/csf/csf.allow"
     regexp="^Include /etc/csf/includes/{{ item.rule }}.allow$"
     line="Include /etc/csf/includes/{{ item.rule }}.allow"
-  with_items: csf_rules
+  with_items: "{{ csf_rules }}"
   when: "csf_rules is defined"
   notify: restart csf
 
 # Copy rules across to the system
 - name: copy common csf rules
-  copy: >
+  template: >
     src="rules/common/{{ item.rule }}.allow"
     dest="/etc/csf/includes/{{ item.rule }}.allow"
     owner=root group=root mode=0600
-  with_items: csf_rules
+  with_items: "{{ csf_rules }}"
   when: "csf_rules is defined"
   notify: restart csf


### PR DESCRIPTION
I've already had this merged in mooash repo but apparently your fork started earlier.

It's super helpful, allowing you to whitelist all hosts from a given group with a simple for loop, for example.